### PR TITLE
Make the command 2.7 compliant

### DIFF
--- a/src/Command/DocCommand.php
+++ b/src/Command/DocCommand.php
@@ -79,12 +79,13 @@ class DocCommand extends ContainerAwareCommand
         $services = array();
         foreach ($this->getContainer()->getServiceIds() as $serviceId) {
             $definition = $container->getDefinition($serviceId);
+            $isShared = method_exists($definition, 'isShared') ? $definition->isShared() : 'prototype' !== $definition->getScope();
             $service['id'] = $serviceId;
             $service['class'] = $definition->getClass() ?: '-';
             $service['public'] = $definition->isPublic() ? 'yes' : 'no';
             $service['synthetic'] = $definition->isSynthetic() ? 'yes' : 'no';
             $service['lazy'] = $definition->isLazy() ? 'yes' : 'no';
-            $service['shared'] = $definition->isShared() ? 'yes' : 'no';
+            $service['shared'] = $isShared ? 'yes' : 'no';
             $service['abstract'] = $definition->isAbstract() ? 'yes' : 'no';
             $service['tags'] = $definition->getTags();
             $service['method_calls'] = $definition->getMethodCalls();

--- a/src/Resources/views/doc.html.twig
+++ b/src/Resources/views/doc.html.twig
@@ -189,7 +189,7 @@ html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:1
                                 <tr>
                                     <th>Factory Service</th>
                                     <td>
-                                        {{ service.factory|length ? service.factory[0] ~ '::' ~ service.factory[1] ~ '()' ?? 'n/a' }}
+                                        {{ service.factory|length ? (service.factory[0].class ?? service.factory[0]) ~ '::' ~ service.factory[1] ~ '()' ?? 'n/a' }}
                                     </td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
PR are not for now (I've not seen the disclaimer before creating this one, it can be deleted) but two points : 

* Before 2.8, the `$definition->isShared()` doesn't exist.
* `service.factory[0]` can be a `Symfony\Component\DependencyInjection\Definition` object