### PR TITLE
Fixes rendering with packages listing no source

### DIFF
--- a/src/Resources/views/doc.html.twig
+++ b/src/Resources/views/doc.html.twig
@@ -266,10 +266,12 @@ html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:1
                                     <td>{{ package.version }}</td>
                                     <td>{{ package.license|join(', ') }}</td>
                                     <td>
-                                        <a href="{{ package.source.url }}">Source</a>
-                                        {% if package.homepage %}
-                                            <span class="text-gray-light">|</span>
-                                            <a href="{{ package.homepage }}">Homepage</a>
+                                        {% if package.source | length > 0 %}
+                                            <a href="{{ package.source.url }}">Source</a>
+                                            {% if package.homepage %}
+                                                <span class="text-gray-light">|</span>
+                                                <a href="{{ package.homepage }}">Homepage</a>
+                                            {% endif %}
                                         {% endif %}
                                     </td>
                                 </tr>


### PR DESCRIPTION
This PR fixes the issue I received from my composer.lock: `Impossible to access an attribute ("url") on a string variable ("").` This issue is caused by a custom packagist with some form of a meta/virtual package to retrieve things like nodejs and yarn:

![image](https://cloud.githubusercontent.com/assets/1754678/22243679/a5dbf2d4-e228-11e6-8744-bba27320d6b9.png)

```
array(4) {
  'name' =>
  string(13) "nodejs/darwin"
  'version' =>
  string(6) "v7.4.0"
  'dist' =>
  array(4) {
    'type' =>
    string(3) "tar"
    'url' =>
    string(60) "https://nodejs.org/dist/v7.4.0/node-v7.4.0-darwin-x64.tar.gz"
    'reference' =>
    NULL
    'shasum' =>
    NULL
  }
  'type' =>
  string(7) "library"
}
/home/ivanderberg/projects/mijn/www/vendor/easycorp/easy-doc-bundle/src/Command/DocCommand.php:114:
array(4) {
  'name' =>
  string(12) "nodejs/linux"
  'version' =>
  string(6) "v7.4.0"
  'dist' =>
  array(4) {
    'type' =>
    string(3) "tar"
    'url' =>
    string(59) "https://nodejs.org/dist/v7.4.0/node-v7.4.0-linux-x64.tar.gz"
    'reference' =>
    NULL
    'shasum' =>
    NULL
  }
  'type' =>
  string(7) "library"
}
/home/ivanderberg/projects/mijn/www/vendor/easycorp/easy-doc-bundle/src/Command/DocCommand.php:114:
array(5) {
  'name' =>
  string(12) "yarnpkg/yarn"
  'version' =>
  string(8) "v0.17.10"
  'dist' =>
  array(4) {
    'type' =>
    string(3) "tar"
    'url' =>
    string(79) "https://github.com/yarnpkg/yarn/releases/download/v0.17.10/yarn-v0.17.10.tar.gz"
    'reference' =>
    NULL
    'shasum' =>
    NULL
  }
  'require' =>
  array(1) {
    'hostnet/node-tool' =>
    string(6) "^1.0.2"
  }
  'type' =>
  string(7) "library"
}
```