### PR TITLE
Redesigned the "Licenses" panel

### DIFF
--- a/src/Command/DocCommand.php
+++ b/src/Command/DocCommand.php
@@ -166,7 +166,7 @@ class DocCommand extends ContainerAwareCommand
         foreach ($composerPackages as $packageConfig) {
             $package = array();
             $package['is_dev'] = $isDev;
-            foreach (array('name', 'description', 'version', 'license', 'homepage', 'type', 'source') as $key) {
+            foreach (array('name', 'description', 'keywords', 'authors', 'version', 'license', 'homepage', 'type', 'source', 'bin', 'autoload', 'time') as $key) {
                 $package[$key] = isset($packageConfig[$key]) ? $packageConfig[$key] : '';
             }
 

--- a/src/Resources/views/_licenses.html.twig
+++ b/src/Resources/views/_licenses.html.twig
@@ -1,5 +1,129 @@
+{% macro clean_url(url) %}
+    {{ url|replace({
+        'https://': '',
+        'http://': '',
+    })|trim('/') }}
+{% endmacro %}
+{% import _self as macros %}
+
 <h1 class="page-title">Licenses</h1>
-<p>These are the packages used by your application and their licenses.</p>
+<p>These are the packages installed in your application and their licenses.</p>
+
+<div class="list-group">
+    <div class="list-group-item list-group-header">
+        <div class="d-flex w-100 justify-content-between">
+            <div class="path">Package</div>
+            <div class="name">License</div>
+        </div>
+    </div>
+
+    {% for package in packages %}
+        <a class="list-group-item flex-column align-items-start package" data-toggle="collapse" href="#package-{{ package.name|replace({ '/': '-' }) }}">
+            <div class="d-flex w-100 justify-content-between">
+                <div class="name">
+                    <span class="badge badge-{{ package.is_dev ? 'outline' : 'prod' }}">{{ package.is_dev ? 'DEV' : 'PROD' }}</span>
+                    {{ package.name }} <span class="text-muted">{{ package.version }}</span>
+                </div>
+                <div class="license">{{ package.license|join(', ') }}</div>
+            </div>
+        </a>
+
+        <div class="collapse" id="package-{{ package.name|replace({ '/': '-' }) }}">
+            <table class="table">
+                <tbody>
+                    <tr>
+                        <th>Authors</th>
+                        <td>
+                            {% for author in package.authors %}
+                                {{ author.name|default('-') }}{% if not loop.last %},{% endif %}
+                            {% else %}
+                                -
+                            {% endfor %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Description</th>
+                        <td>{{ package.description ?: '-' }}</td>
+                    </tr>
+                    <tr>
+                        <th>Keywords</th>
+                        <td>{{ package.keywords|join(', ') ?: '-' }}</td>
+                    </tr>
+                    <tr>
+                        <th>Type</th>
+                        <td>{{ package.type ?: '-' }}</td>
+                    </tr>
+                    <tr>
+                        <th>Homepage</th>
+                        <td>
+                            {% if package.homepage %}
+                                <a href="{{ package.homepage }}">{{ macros.clean_url(package.homepage) }}</a>
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Source</th>
+                        <td>
+                            {% if package.source|length > 0 %}
+                                <a href="{{ package.source.url }}">{{ package.source.url }}</a>
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Published on</th>
+                        <td>{{ package.time|date }}</td>
+                    </tr>
+                    <tr>
+                        <th>Binaries</th>
+                        <td>
+                            {% if package.bin|length > 0 %}
+                                <ul>
+                                    {% for binary in package.bin %}
+                                        <li>{{ binary }}</li>
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>PHP autoload</th>
+                        <td>
+                            {% if package.autoload|length > 0 %}
+                                <ul>
+                                    {% for type, autoload in package.autoload if autoload != 'exclude-from-classmap' %}
+                                        <li><b>{{ type }}</b>:
+                                            <ul>
+                                                {% if type in ['psr-0', 'psr-4'] %}
+                                                    {% for namespace, dir in autoload %}
+                                                        <li>{{ namespace }} &rarr; "{{ dir|join('", "') }}"</li>
+                                                    {% endfor %}
+                                                {% endif %}
+
+                                                {% if type in ['classmap', 'files', 'exclude-from-classmap'] %}
+                                                    {% for entry in autoload %}
+                                                        <li>{{ entry }}</li>
+                                                    {% endfor %}
+                                                {% endif %}
+                                            </ul>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    {% endfor %}
+</div>
 
 <table class="table">
     <thead>

--- a/src/Resources/views/doc.html.twig
+++ b/src/Resources/views/doc.html.twig
@@ -11,6 +11,7 @@
         }
 
         .nowrap { white-space: pre; }
+        .text-muted { color: #999 !important; }
 
         .navbar-top {
             background-color: #444;
@@ -41,14 +42,8 @@
         }
         aside .nav-link:hover { background: rgba(0, 0, 0, 0.05); }
         aside .nav-link.active { font-weight: bold; background: rgba(0, 0, 0, 0.1); }
-        article {
-            margin-left: 30px;
-            flex: 0 0 960px;
-        }
-        article section {
-            margin-bottom: 1280px;
-            padding-top: 51px;
-        }
+        article { margin-left: 30px; margin-right: 15px; }
+        article section { margin-bottom: 1280px; padding-top: 51px; }
         footer {
             position: absolute;
             bottom: 15px;
@@ -82,7 +77,6 @@
         .table tbody th { vertical-align: top; width: 15%; }
         .table h3 { font-size: 1rem; font-weight: 500; margin: 0; }
         .markdown-body table tbody td, .code { font-family: Ubuntu Mono, Consolas, Inconsolata, Monaco, monospace; word-break: break-all; }
-        .table tbody td ul { margin-bottom: 0; }
         .table tbody td span + b { margin-left: 1rem; }
         .table tbody td ul + b { display: inline-block; margin-top: 1rem; }
 
@@ -123,10 +117,10 @@
             padding: 4px;
         }
         .badge-outline { background-color: #fff; border: 2px solid #eee; }
-        .badge-prod {
-            border-color: #5cb85c;
-            color: #5cb85c;
-        }
+        .badge-prod { background-color: #709c8d; color: #FFF; }
+        .badge-get, .badge-head, .badge-options { background-color: #709c8d; color: #FFF; }
+        .badge-post, .badge-put, .badge-patch { background-color: #72809d; color: #FFF; }
+        .badge-delete { background-color: #9d7280; color: #FFF; }
 
         .list-group-item { padding: .75rem; }
         a.list-group-item:hover { background-color: #fff9ea; }
@@ -136,15 +130,20 @@
         .list-group .table tr:last-child td,
         .list-group .table tr:last-child th { border-bottom: 0; }
 
+        .list-group ul { list-style: none; padding-left: 0 }
+        .list-group li { margin: 0 0 .25rem; }
+        .list-group ul ul { list-style: disc; padding-left: 1.5rem; margin-bottom: 1rem; }
+        .list-group td > ul, .list-group td > ul li:last-child ul { margin-bottom: 0; }
+
         .tab-pane p { margin: 1rem 0; }
 
         /* Routes panel */
         .route .name { color: #292b2c; }
         .route .path .badge:last-child { margin-right: 5px; }
 
-        .badge-get, .badge-head, .badge-options { background-color: #709c8d; color: #FFF; }
-        .badge-post, .badge-put, .badge-patch { background-color: #72809d; color: #FFF; }
-        .badge-delete { background-color: #9d7280; color: #FFF; }
+        /* Licenses panel */
+        .package .license { color: #292b2c; }
+        .package .badge { margin-right: 5px; min-width: 40px; }
     </style>
     <script>{{ source('@EasyDoc/assets/all.js') }}</script>
 </head>


### PR DESCRIPTION
This new design matches the compact design introduced recently for the "Routes" panel. The rest of panels will be updated soon.

### Listing

![licenses-list](https://cloud.githubusercontent.com/assets/73419/22481120/4f674d14-e7f4-11e6-9437-6ce65229cabf.png)

### Detail

Visible when you click on any row:

![licenses-detail](https://cloud.githubusercontent.com/assets/73419/22481122/52e06520-e7f4-11e6-8a59-4e7f856eb6fa.png)
